### PR TITLE
Cater for puppetlabs apt (2.0.1) refactoring.

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -12,20 +12,23 @@
 #
 
 class serverdensity_agent::apt {
-    $repo_baseurl = 'http://www.serverdensity.com/downloads/linux/deb'
-    $repo_keyurl = 'https://www.serverdensity.com/downloads/boxedice-public.key'
+  $repo_baseurl = 'http://www.serverdensity.com/downloads/linux/deb'
+  $repo_keyurl  = 'https://www.serverdensity.com/downloads/boxedice-public.key'
 
-    apt::source { 'serverdensity_agent':
-        location    => $repo_baseurl,
-        release     => 'all',
-        repos       => 'main',
-        key         => '0FB77536E797A2DE23AD2FC443D26D8613C2E6F8',
-        key_source  => $repo_keyurl,
-        include_src => false
+  apt::source { 'serverdensity_agent':
+    location => $repo_baseurl,
+    release  => 'all',
+    repos    => 'main',
+    key      => {
+      id     => '0FB77536E797A2DE23AD2FC443D26D8613C2E6F8',
+      source => $repo_keyurl,
+    },
+    include  => {
+      src => false,
     }
-    package {
-            'sd-agent':
-                    ensure  => 'present',
-                    require => Apt::Source['serverdensity_agent'],
-    }
+  }
+  package { 'sd-agent':
+    ensure  => 'present',
+    require => Apt::Source['serverdensity_agent'],
+  }
 }


### PR DESCRIPTION
Good day

The puppet labs apt module has changed the way that apt::source handles a few definition variables.
I.e. Variables include and key.

I hope you dont mind I realigned a few variables.

Please see my pull request.
Kind Regards
Brent Clark
