### PR TITLE
SD 823 improve api response handling

### DIFF
--- a/lib/puppet/parser/functions/agent_key.rb
+++ b/lib/puppet/parser/functions/agent_key.rb
@@ -26,12 +26,12 @@ def sd_device(base_url, token, filter_json)
         if list['errors'].any?{ |e| e['type'] == 'invalid_command'  }
             raise Puppet::ParseError, "SD API: " + list['message']
         elsif list['errors'].any?{ |e| e['subject'] == 'device' &&  e['type'] == 'not_found'  }
-            raise NameError.new(list['message'])
+            raise NameError, list['message']
         end
     end
 
     if list.nil? or list.empty?
-        raise NameError.new("Device not found")
+        raise NameError, "Device not found"
     end
 
     if list.length > 1

--- a/lib/puppet/parser/functions/agent_key.rb
+++ b/lib/puppet/parser/functions/agent_key.rb
@@ -2,6 +2,83 @@ require 'net/http'
 require 'net/https'
 require 'uri'
 
+def sd_device(base_url, token, filter_json)
+    begin
+        uri = URI("#{ base_url }/inventory/devices?filter=#{ filter_json }&token=#{ token }")
+        req = Net::HTTP::Get.new(uri.request_uri)
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+        https.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        res = https.start { |cx| cx.request(req) }
+
+        list = PSON.parse(res.body)
+    rescue => e
+        err "Unhandled error"
+        err e
+        raise Puppet::ParseError, "Error from SD API"
+    end
+
+    if Integer(res.code) >= 500
+        raise Puppet::ParseError, "Error from SD API"
+    end
+
+    if Integer(res.code) == 404 && list.has_key?('errors')
+        if list['errors'].any?{ |e| e['type'] == 'invalid_command'  }
+            raise Puppet::ParseError, "SD API: " + list['message']
+        elsif list['errors'].any?{ |e| e['subject'] == 'device' &&  e['type'] == 'not_found'  }
+            raise NameError.new(list['message'])
+        end
+    end
+
+    if list.nil? or list.empty?
+        raise NameError.new("Device not found")
+    end
+
+    if list.length > 1
+        raise RangeError, "More than one existing device matches this hostname or fqdn. Please manually set token"
+    end
+    device = list[0]
+    return device
+
+
+end
+
+def sd_create_device(base_url, token, data)
+    uri = URI("#{ base_url }/inventory/devices?token=#{ token }")
+    req = Net::HTTP::Post.new(uri.request_uri)
+
+    # Create new device
+    req.set_form_data(data)
+
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+    https.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    res = https.start { |cx| cx.request(req) }
+
+    if Integer(res.code) >= 500
+        err ["Error from SD API, stopping run"]
+        raise Puppet::ParseError, "Error from SD API"
+    end
+
+    device = PSON.parse(res.body)
+    return device
+end
+
+def sd_update_device(base_url, token, device, update_data)
+
+    # update the group
+    uri = URI("#{ base_url }/inventory/devices/#{ device['_id'] }?token=#{ token }")
+
+    req = Net::HTTP::Put.new(uri.request_uri)
+
+    req.set_form_data(update_data)
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+    https.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    res = https.start { |cx| cx.request(req) }
+end
+
+
 module Puppet::Parser::Functions
 
     newfunction(:agent_key, :type => :rvalue) do |args|
@@ -34,7 +111,6 @@ module Puppet::Parser::Functions
             # then we should check hostname and fqdn
             checks = [hostname, fqdn]
         end
-
 
         notice ["Server Name: #{ server_name }"]
 
@@ -70,7 +146,7 @@ module Puppet::Parser::Functions
 
         base_url = "https://api.serverdensity.io"
 
-        list = nil
+        device = nil
         if provider and provider_id
             # attempt to find the device by providerId
             filter = {
@@ -84,28 +160,20 @@ module Puppet::Parser::Functions
             notice ["Making API request for provider: #{ provider } and providerId: #{ provider_id }"]
             filter_json = URI.escape(PSON.dump(filter))
             begin
-                uri = URI("#{ base_url }/inventory/devices?filter=#{ filter_json }&token=#{ token }")
-                req = Net::HTTP::Get.new(uri.request_uri)
-                https = Net::HTTP.new(uri.host, uri.port)
-                https.use_ssl = true
-                https.verify_mode = OpenSSL::SSL::VERIFY_NONE
-                res = https.start { |cx| cx.request(req) }
-
-                list = PSON.parse(res.body)
-
-            rescue
-                err ["Error from SD API, stopping run"]
-                raise Puppet::ParseError, "Error from SD API"
+                device = sd_device(base_url, token, filter_json)
+            rescue RangeError => e
+                # Filter returns more than a single device
+                err e.message
+                break
+            rescue NameError
+            # Device not found
+            rescue => e
+                err "unhandled e"
+                err e
             end
-
-            if Integer(res.code) >= 500
-                err ["Error from SD API, stopping run"]
-                raise Puppet::ParseError, "Error from SD API"
-            end
-
         end
 
-        if list.nil? or list.empty?
+        if device.nil?
             # attempt to find the device by hostname (which may be local or FQDN)
             list = nil
             checks.each do |hn|
@@ -133,33 +201,22 @@ module Puppet::Parser::Functions
                 notice ["Making API request for hostname: #{ hn }"]
 
                 begin
-                    uri = URI("#{ base_url }/inventory/devices?filter=#{ filter_json }&token=#{ token }")
-                    req = Net::HTTP::Get.new(uri.request_uri)
-                    https = Net::HTTP.new(uri.host, uri.port)
-                    https.use_ssl = true
-                    https.verify_mode = OpenSSL::SSL::VERIFY_NONE
-                    res = https.start { |cx| cx.request(req) }
-
-                    list = PSON.parse(res.body)
-
-                rescue
-                    err ["Error from SD API, stopping run"]
-                    raise Puppet::ParseError, "Error from SD API"
-                end
-
-                if Integer(res.code) >= 500
-                    err ["Error from SD API, stopping run"]
-                    raise Puppet::ParseError, "Error from SD API"
-                end
-
-                if list.length > 0
-                    # keep this response -- device was found
+                    device = sd_device(base_url, token, filter_json)
                     break
+                rescue RangeError => e
+                    # Filter returns more than a single device
+                    err e.message
+                    break
+                rescue NameError
+                # Device not found
+                rescue => e
+                    err e
                 end
+
             end
         end
 
-        if Integer(res.code) >= 300 or list.length == 0
+        if device.nil?
             notice ["Device not found, creating a new one"]
 
             data = {
@@ -176,49 +233,18 @@ module Puppet::Parser::Functions
                     data['providerId'] = provider_id
                 end
             end
-
-            uri = URI("#{ base_url }/inventory/devices?token=#{ token }")
-            req = Net::HTTP::Post.new(uri.request_uri)
-
-            # Create new device
-            req.set_form_data(data)
-
-            https = Net::HTTP.new(uri.host, uri.port)
-            https.use_ssl = true
-            https.verify_mode = OpenSSL::SSL::VERIFY_NONE
-            res = https.start { |cx| cx.request(req) }
-
-            if Integer(res.code) >= 500
-                err ["Error from SD API, stopping run"]
-                raise Puppet::ParseError, "Error from SD API"
-            end
-
-            device = PSON.parse(res.body)
-        elsif list.length > 1
-            fail ["More than one existing device matches this hostname or fqdn. Please manually set token"]
+            device = sd_create_device(base_url, token, data)
         else
-            device = list[0]
-
             # Has the group changed?
             existing_group = device["group"]
 
             if existing_group != group
                 notice ["Updating group on #{device['_id']} from #{existing_group} to #{group}"]
-
-                # update the group
-                uri = URI("#{ base_url }/inventory/devices/#{ device['_id'] }?token=#{ token }")
-
-                req = Net::HTTP::Put.new(uri.request_uri)
-
                 update_data = {
                     :group => group
                 }
-                req.set_form_data(update_data)
-                https = Net::HTTP.new(uri.host, uri.port)
-                https.use_ssl = true
-                https.verify_mode = OpenSSL::SSL::VERIFY_NONE
-                res = https.start { |cx| cx.request(req) }
 
+                sd_update_device(base_url, token, device, update_data)
             end
         end
 


### PR DESCRIPTION
#### What's this PR do?

Currently we fail the puppet run if there's an error while contacting the API. We want to avoid that in case an API key is provided by the user or has been already configured.

On top of that we are catching more errors and refactoring the API interactions to avoid code duplication.
#### Where should the reviewer start?

Pending
#### How should this be manually tested?

A puppet run can be manually applied with a manifest like:

```
class { 'serverdensity_agent':
  sd_url       => 'https://example.serverdensity.io',
  api_token    => 'apikey',
  server_group => 'test',
#  agent_key    => 'agentkey'
}
```

We can use the `agent_key` to check the behaviour when one is provided by the user

We should check that the following actions are performed and reflected in the dashboard:
- The device is created when it does not exist
- If we specify a group, the device group is changed

These situations constitute an error:
- If we create another device in the dashboard with the same hostname
- If the API cannot be contacted

In these situations a warning is raised if an `agent_key` is provided either by a fact or by a parameter in the manifest. If there is not a provided `agent_key` then the puppet run will fail.
#### Any background context you want to provide?

n/a
#### What are the relevant tickets?

https://serverdensity.atlassian.net/browse/SD-823
