### PR TITLE
Add FreeBSD 10 support for sd-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Puppet Module for deploying the Server Density Agent and agent plugins
 
 * Ubuntu
 * CentOS
+* FreeBSD
 
 ## Usage
 

--- a/lib/facter/agent_key.rb
+++ b/lib/facter/agent_key.rb
@@ -2,7 +2,7 @@ require 'facter'
 require 'net/http'
 require 'uri'
 
-Facter.add(:sd_agent_key, :timeout => 10) do
+Facter.add(:sd_agent_key) do
 
     # just in case we don't get any of them
     result = nil

--- a/lib/puppet/provider/package/sd_pip.rb
+++ b/lib/puppet/provider/package/sd_pip.rb
@@ -1,0 +1,14 @@
+require 'puppet/provider/package'
+require 'uri'
+
+# Ruby gems support.
+Puppet::Type.type(:package).provide :sd_pip, :parent => :pip do
+
+  has_feature :installable, :uninstallable, :upgradeable, :versionable
+
+  def self.cmd
+    "/usr/share/python/sd-agent/bin/pip"
+  end
+end
+
+#  vim: set ts=2 sw=2 tw=0 et:

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -14,7 +14,7 @@
 class serverdensity_agent::config_file (
   $api_token,
   $provided_agent_key = $::sd_agent_key,
-  $server_name,
+  $sd_account,
   $server_group,
   $use_fqdn,
   $proxy_host = undef,

--- a/manifests/freebsd.pp
+++ b/manifests/freebsd.pp
@@ -1,0 +1,12 @@
+# == Class: serverdensity_agent::freebsd
+#
+# Installs the sd-agent package
+#
+
+class serverdensity_agent::freebsd {
+    # install SD agent package
+    package { 'sd-agent':
+        ensure  => present,
+        require => Class['pkgng']
+    }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class serverdensity_agent(
   $proxy_password = undef,
   $proxy_forbid_method_switch = undef,
   $v1_plugin_directory = '/usr/local/sd-agent-plugins',
-  $log_level = undef,
+  $log_level = 'INFO',
   $collector_log_file = undef,
   $forwarder_log_file = undef,
   $log_to_syslog = undef,
@@ -134,6 +134,7 @@ class serverdensity_agent(
     use_fqdn           => $use_fqdn ,
     log_level          => $log_level,
     require            => Package['sd-agent'],
+    sd_account         => $sd_account,
     notify             => Class['serverdensity_agent::service']
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,18 @@ class serverdensity_agent(
         require => Class['serverdensity_agent::yum'],
       }
     }
+    'FreeBSD': {
+      include serverdensity_agent::freebsd
+      $location = '/usr/local/etc/sd-agent/conf.d'
+
+      file { 'sd-agent-v1-plugin-dir':
+        ensure  => directory,
+        path    => $v1_plugin_directory,
+        mode    => '0755',
+        notify  => Class['serverdensity_agent::service'],
+        require => Class['serverdensity_agent::freebsd'],
+      }
+    }
     default: {
       fail("OSfamily ${::operatingsystem} not supported.")
     }

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -12,10 +12,10 @@
 #
 
 class serverdensity_agent::yum {
-  $repo_baseurl = 'http://archive.serverdensity.com/el/$releasever'
+  $repo_baseurl = "http://archive.serverdensity.com/el/${::operatingsystemmajrelease}"
 
   # March 31, 2017 can't arrive soon enough
-  if $::operatingsystemmajrelease >= 5 and $::operatingsystemmajrelease < 6 {
+  if $::operatingsystemmajrelease >= '5' and $::operatingsystemmajrelease < '6' {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-el5-public.key'
   } else {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -15,7 +15,7 @@ class serverdensity_agent::yum {
   $repo_baseurl = 'http://archive.serverdensity.com/el/$releasever'
 
   # March 31, 2017 can't arrive soon enough
-  if $::operatingsystemrelease >= 5 and $::operatingsystemrelease < 6 {
+  if $::operatingsystemmajrelease >= 5 and $::operatingsystemmajrelease < 6 {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-el5-public.key'
   } else {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": “2.0.2”,
+  "version": "2.0.2",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",

--- a/metadata.json
+++ b/metadata.json
@@ -20,12 +20,19 @@
     },
     {
       "operatingsystem": "CentOS"
+    },
+    {
+      "operatingsystem": "FreeBSD"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/apt",
       "version_requirement": ">= 1.8.0"
+    },
+    {
+      "name": "zleslie/pkgng",
+      "version_requirement": ">= 0.2.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.0.1",
+  "version": “2.0.2”,
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",


### PR DESCRIPTION
This adds basic FreeBSD support using pkgng. There is an issue where the $plugin_directory default should be different for FreeBSD, this can be worked around by setting `plugin_directory => '/usr/local/libexec/sd-agent/plugins',` as a class parameter wherever the serverdensity_agent class is defined.