### PR TITLE
Rollback gce changes in 1.4 cleanup

### DIFF
--- a/lib/puppet/parser/functions/agent_key.rb
+++ b/lib/puppet/parser/functions/agent_key.rb
@@ -23,10 +23,6 @@ module Puppet::Parser::Functions
 
         if server_name.nil? or server_name.empty?
             server_name = fqdn
-            if provider == 'google'
-                hn_split = fqdn.split(".")
-                server_name = hn_split[0..-4].join('.')
-            end
         end
 
         if use_fqdn
@@ -115,10 +111,12 @@ module Puppet::Parser::Functions
             checks.each do |hn|
                 # attempt to detect google cloud devices
                 if provider == 'google'
+                    hn_split=hn.split(".")
+                    name=hn_split[0..-4].join('.')
                     filter = {
                         'type' => 'device',
                         'deleted' => false,
-                        'name' => server_name,
+                        'name' => name,
                         'projectId' => project_id,
                         'provider' => 'google'
                     }

--- a/lib/puppet/parser/functions/agent_key.rb
+++ b/lib/puppet/parser/functions/agent_key.rb
@@ -177,9 +177,6 @@ module Puppet::Parser::Functions
                 if provider_id
                     data['providerId'] = provider_id
                 end
-                if project_id
-                    data['projectId'] = project_id
-                end
             end
 
             uri = URI("#{ base_url }/inventory/devices?token=#{ token }")


### PR DESCRIPTION
#### What's this PR do?
The 1.4 removal PR (#43)  included a patch to avoid node duplication detected in the machine `test-new-puppet-serverdensity` (Ubuntu 12.04, pe-agent 3.3.2-1puppet1) . Once merged it was detected that the behaviour in `puppet.eur.gce` was different and that it was duplicating instances.

This PR reverts this changes.

#### Where should the reviewer start?

Check that the changes in this PR revert:
- 46f7473 Coherent use of server_name in GCE
- f5b9877 Add projectId if it is available


#### How should this be manually tested?
Change the puppet module on the puppet master to this branch (rollback-gce-changes) and do a puppet run in `puppet.eur.gce` to check that the node is not getting duplicated.

#### What are the relevant tickets?
https://serverdensity.atlassian.net/browse/SD-1469