### PR TITLE
Stop default variables in facter being set to undef

### DIFF
--- a/lib/facter/agent_key.rb
+++ b/lib/facter/agent_key.rb
@@ -5,7 +5,7 @@ require 'uri'
 Facter.add(:sd_agent_key, :timeout => 10) do
 
     # just in case we don't get any of them
-    result = nil
+    result = ''
 
     # We inject this file using the Rackspace api
     # on instance creation

--- a/lib/facter/sd.rb
+++ b/lib/facter/sd.rb
@@ -41,5 +41,10 @@ if provider
         Facter.add(:sd_project_id) { setcode { projectid } }
     end
 else
+    #If we don't set these, strict_variables will cry
+    Facter.add(:sd_provider) { setcode { '' } }
+    Facter.add(:sd_provider_id) { setcode { '' } }
+    Facter.add(:sd_project_id) { setcode { '' } }
+    
     Facter.debug "Unknown provider"
 end

--- a/lib/puppet/parser/functions/agent_key.rb
+++ b/lib/puppet/parser/functions/agent_key.rb
@@ -46,14 +46,10 @@ module Puppet::Parser::Functions
         agent_key = lookupvar("sd_agent_key")
 
         # lookupvar returns undef if no value
-        # test against nil just in case
-        unless agent_key.nil? or agent_key == :undefined or agent_key == :undef
+        # test against no key just in case
+        unless agent_key.eql? "" 
             notice ["Agent Key Provided via Facter: #{ agent_key }"]
             return agent_key
-        end
-
-        if agent_key == :undef
-            agent_key = ""
         end
 
         notice ["Using SD Version 2"]


### PR DESCRIPTION
Stop default variables from facter being set to undef as strict_variables doesn't like it.

Fixes: #50
