### PR TITLE
use operatingsystemmajrelease instead

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -15,7 +15,7 @@ class serverdensity_agent::yum {
   $repo_baseurl = 'http://archive.serverdensity.com/el/$releasever'
 
   # March 31, 2017 can't arrive soon enough
-  if $::operatingsystemrelease >= 5 and $::operatingsystemrelease < 6 {
+  if $::operatingsystemmajrelease >= 5 and $::operatingsystemmajrelease < 6 {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-el5-public.key'
   } else {
     $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'


### PR DESCRIPTION
It could be our slightly out-dated PE version, or it could be that we run CentOS and not RHEL or SL, but I had to use operatingsystemmajrelease to get agents deployed properly. 