### PR TITLE
Adds a ServerDensity pip provider to allow installation of additional libraries.

### DIFF
--- a/lib/puppet/provider/package/sd_pip.rb
+++ b/lib/puppet/provider/package/sd_pip.rb
@@ -1,0 +1,14 @@
+require 'puppet/provider/package'
+require 'uri'
+
+# Ruby gems support.
+Puppet::Type.type(:package).provide :sd_pip, :parent => :pip do
+
+  has_feature :installable, :uninstallable, :upgradeable, :versionable
+
+  def self.cmd
+    "/usr/share/python/sd-agent/bin/pip"
+  end
+end
+
+#  vim: set ts=2 sw=2 tw=0 et:


### PR DESCRIPTION
DISCLAIMER: I have only tested this on CentOS6. It is entirely installation dependent and almost certainly needs more love before it is mergable.

This is a pattern I have copied from the [`pe_gem`](https://github.com/puppetlabs/puppetlabs-pe_gem) module.

```
  package { 'sd-iso8601':
    name     => 'iso8601',
    ensure   => installed,
    provider => 'sd_pip',
  }

  serverdensity_agent::plugin::v1 { 'Plugin1':
    source  => "puppet:///modules/${module_name}/Plugin1.py",
    config  => {},
    require => Package['sd-iso8601'],
    notify  => Service['sd-agent'],
  }
```