### PR TITLE
Pass sd_url to `serverdensity_agent::config_file`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.2
+  - 1.9.3
 script: 'puppet parser validate `find . manifests -name "*.pp"`'
 script: 'puppet-lint --no-autoloader_layout-check --with-filename manifests'
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 if ENV.key?('PUPPET_VERSION')
   puppetversion = "= #{ENV['PUPPET_VERSION']}"
@@ -9,4 +9,4 @@ end
 gem 'rake'
 gem 'puppet-lint'
 gem 'rspec-puppet'
-gem 'json'
+gem 'json', '<= 1.8.3'

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -17,6 +17,7 @@ class serverdensity_agent::config_file (
   $sd_account,
   $server_group,
   $use_fqdn,
+  $sd_url = undef,
   $proxy_host = undef,
   $proxy_port = undef,
   $proxy_user = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,7 @@ class serverdensity_agent(
     api_token          => $api_token,
     provided_agent_key => $agent_key,
     server_name        => $server_name,
+    sd_url             => $sd_url,
     server_group       => $server_group,
     use_fqdn           => $use_fqdn ,
     log_level          => $log_level,


### PR DESCRIPTION
Recent events brought to light that `sd_url` was not passed to `serverdensity_agent::config_file`.
This PR fixes that.