### PR TITLE
Update for new deb repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ Puppet Module for deploying the Server Density Agent and agent plugins
 
 ### Platforms
 
-* Ubuntu
+* Amazon Linux
 * CentOS
+* RHEL
+* Debian
+* Ubuntu
+
+> Support for Ubuntu Precise is now deprecated and agent updates are no longer provided after 2.1.6. This mainfest will install agent 2.1.6 for any server detected as Ubuntu Precise
 
 ## Usage
 

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -12,12 +12,30 @@
 #
 
 class serverdensity_agent::apt {
-  $repo_baseurl = 'http://archive.serverdensity.com/ubuntu'
+  $repo_location = $::lsbdistcodename ? {
+    'artful'  => 'xenial',
+    'precise' => 'all',
+    'quantal' => 'all',
+    'raring'  => 'all',
+    'saucy'   => 'all',
+    'trusty'  => 'trusty',
+    'utopic'  => 'trusty',
+    'vivid'   => 'trusty',
+    'wily'    => 'trusty',
+    'yakkety' => 'xenial',
+    'xenial'  => 'xenial',
+    'zesty'   => 'xenial',
+    'wheezy'  => 'wheezy',
+    'jessie'  => 'jessie',
+    'stretch' => 'stretch',
+  }
+
+  $repo_baseurl = "http://archive.serverdensity.com/${downcase($::lsbdistid)}"
   $repo_keyurl  = 'https://archive.serverdensity.com/sd-packaging-public.key'
 
   apt::source { 'serverdensity_agent':
     location => $repo_baseurl,
-    release  => 'all',
+    release  => $repo_location,
     repos    => 'main',
     key      => {
       'id'     => '4381EE1BA673897A16AC92D43B2F6FF074371316',

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -28,6 +28,26 @@ class serverdensity_agent::yum {
     enabled  => 1,
     gpgcheck => 1,
   }
+
+  if $::operatingsystemmajrelease >= '6' and $::operatingsystemmajrelease < '7' {
+    package { 'epel-release':
+      ensure   => installed,
+      provider => 'rpm',
+      source   => 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm'
+    }
+    if downcase($::lsbdistid) == 'centos' {
+      $location = downcase($::lsbdistid)
+    }
+    else {
+      $location = 'rhel'
+    }
+    package { 'ius-release':
+      ensure   => installed,
+      provider => 'rpm',
+      source   => "https://${location}6.iuscommunity.org/ius-release.rpm"
+    }
+  }
+
   # install SD agent package
   package { 'sd-agent':
     ensure  => present,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",


### PR DESCRIPTION
Adds the new, split repositories for the debian packages. 

Tested on trusty, xenial and stretch.

```
# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
# cat /etc/apt/sources.list.d/serverdensity_agent.list 
# This file is managed by Puppet. DO NOT EDIT.
# serverdensity_agent
deb http://archive.serverdensity.com/ubuntu trusty main
```

```
# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.3 LTS"
root@puppet:~# cat /etc/apt/sources.list.d/serverdensity_agent.list 
# This file is managed by Puppet. DO NOT EDIT.
# serverdensity_agent
deb http://archive.serverdensity.com/ubuntu xenial main
```

```
# cat /etc/debian_version 
9.2
# cat /etc/apt/sources.list.d/serverdensity_agent.list 
# This file is managed by Puppet. DO NOT EDIT.
# serverdensity_agent
deb http://archive.serverdensity.com/debian stretch main
```

This also installs the epel and ius repositories on el6 to allow the python27 dep to be satisfied: 
```
Notice: /Stage[main]/Serverdensity_agent::Yum/Package[epel-release]/ensure: created
Notice: /Stage[main]/Serverdensity_agent::Yum/Package[ius-release]/ensure: created
```

@carlosperello please can you review? 