### PR TITLE
Amazon linux uses el6 repo

### DIFF
--- a/manifests/amazon.pp
+++ b/manifests/amazon.pp
@@ -1,0 +1,30 @@
+# == Class: serverdensity_agent::amazon
+#
+# Sets up the yum repository for the agent on amazon linux servers
+#
+# === Authors
+#
+# Server Density <hello@serverdensity.com>
+#
+# === Copyright
+#
+# Copyright 2014 Server Density
+#
+
+class serverdensity_agent::amazon {
+  $repo_baseurl = "http://archive.serverdensity.com/el/6"
+  $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'
+
+  yumrepo { 'serverdensity_agent':
+    baseurl  => $repo_baseurl,
+    gpgkey   => $repo_keyurl,
+    descr    => 'Server Density',
+    enabled  => 1,
+    gpgcheck => 1,
+  }
+  # install SD agent package
+  package { 'sd-agent':
+    ensure  => present,
+    require => Yumrepo['serverdensity_agent']
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,15 +106,19 @@ class serverdensity_agent(
       }
     }
     'RedHat': {
-      include serverdensity_agent::yum
-
-      file { 'sd-agent-v1-plugin-dir':
-        ensure  => directory,
-        path    => $v1_plugin_directory,
-        mode    => '0755',
-        notify  => Class['serverdensity_agent::service'],
-        require => Class['serverdensity_agent::yum'],
+      if $facts['os']['name'] == 'Amazon' {
+        include serverdensity_agent::amazon
       }
+      else {
+        include serverdensity_agent::yum
+      }
+        file { 'sd-agent-v1-plugin-dir':
+          ensure  => directory,
+          path    => $v1_plugin_directory,
+          mode    => '0755',
+          notify  => Class['serverdensity_agent::service'],
+          require => Package['sd-agent'],
+        }
     }
     default: {
       fail("OSfamily ${::operatingsystem} not supported.")


### PR DESCRIPTION
This PR sets amazon OS's to use the el6 repository. 

Tested on `Amazon Linux AMI release 2017.09` 

```
# puppet apply mani.pp
Warning: Facter: timeout option is not supported for custom facts and will be ignored.
Warning: /etc/puppetlabs/puppet/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
   (in /etc/puppetlabs/puppet/hiera.yaml)
Notice: Scope(Class[Serverdensity_agent::Config_file]): Agent Key Provided: 1234567890abcdef
Notice: Compiled catalog for ip-172-30-0-53.eu-west-1.compute.internal in environment production in 0.20 seconds
Notice: /Stage[main]/Serverdensity_agent::Amazon/Package[sd-agent]/ensure: created
Notice: /Stage[main]/Serverdensity_agent::Config_file/File[/etc/sd-agent/config.cfg]/content: content changed '{md5}79492a2017a351f5b40c33f24ea9d126' to '{md5}0ccd37be00398ca8f060006b492187be'
Notice: /Stage[main]/Serverdensity_agent::Config_file/File[/etc/sd-agent/config.cfg]/mode: mode changed '0660' to '0644'
Notice: /Stage[main]/Serverdensity_agent::Service/Service[sd-agent]: Triggered 'refresh' from 2 events
Notice: Applied catalog in 21.30 seconds
# cat /etc/yum.repos.d/serverdensity_agent.repo 
[serverdensity_agent]
name=Server Density
baseurl=http://archive.serverdensity.com/el/6
enabled=1
gpgcheck=1
gpgkey=https://archive.serverdensity.com/sd-packaging-public.key
```

@carlosperello please can you review? 