### PR TITLE
Add Network & Disk plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ class { 'serverdensity_agent::plugin::rabbitmq':
 - pidfile_directory
 - logtail_paths
 
+### New Classes
+#### Disk
+Check the class documentation for further details. Basic example:
+```puppet
+class { 'serverdensity_agent::plugin::disk':
+    use_mount              => 'no',
+    excluded_filesystems   => ['tmpfs', 'run'],
+    excluded_disks         => ['/dev/sda', '/dev/sdb'],
+    excluded_disk_re     => '/dev/sda.*',
+    excluded_mountpoint_re => '/mnt/no-monitor.*',
+    all_partitions         => false,
+    tag_by_filesystem    => 'yes'
+ }
+ ```
+
+#### Network
+Check the class documentation for further details. Basic example:
+```puppet
+class { 'serverdensity_agent::plugin::network':
+  excluded_interfaces => ['lo','lo0'],
+  collect_connection_state  => true,
+  excluded_interface_re => [],
+  combine_connection_states => true
+}
+```
 
 ## Known issues
 

--- a/manifests/plugin/disk.pp
+++ b/manifests/plugin/disk.pp
@@ -1,0 +1,62 @@
+# == Class: serverdensity_agent::plugin::disk
+#
+# Defines Disk plugin configuration
+#
+# === Parameters
+#
+# [*use_mount*]
+#   Boolean. Use mount points to collect disk and fs metrics instead of volumes
+#   Values should be set to either 'yes' or 'no'
+#   Default: no
+#
+# [*excluded_filesystems*]
+#   String/Array. The filesystems to be excluded from the check
+#   Default: undef
+#
+# [*excluded_disks*]
+#   String/Array The disks to be excluded from the check
+#   Default: undef
+#
+# [*excluded_disk_re*]
+#   String. Regex to excude disks.
+#   Default: undef
+#
+# [*excluded_mountpoint_re*]
+#   String. Regex to excude mountpoints.
+#   Default: undef
+#
+# [*all_partitions*]
+#   Boolean. Instructs agent to collect metrics for all partitions
+#   user_mount must be enabled for this option
+#   Default: undef
+#
+# [*tag_by_filesystem*]
+#   Boolean. Have the check tag disk metrics with their filesystem
+#   Values should be set to either 'yes' or 'no'
+#   Default: undef
+#
+# === Examples
+#
+# class { 'serverdensity_agent::plugin::disk':
+#    use_mount              => 'no',
+#    excluded_filesystems   => ['tmpfs', 'run'],
+#    excluded_disks         => ['/dev/sda', '/dev/sdb'],
+#    excluded_disk_re       => '/dev/sda.*',
+#    excluded_mountpoint_re => '/mnt/no-monitor.*',
+#    all_partitions         => false,
+#    tag_by_filesystem      => 'yes'
+# }
+#
+class serverdensity_agent::plugin::disk (
+    $use_mount              = 'no',
+    $excluded_filesystems   = undef,
+    $excluded_disks         = undef,
+    $excluded_disk_re       = undef,
+    $excluded_mountpoint_re = undef,
+    $all_partitions         = undef,
+    $tag_by_filesystem      = undef
+  ) {
+  serverdensity_agent::plugin { 'disk':
+    config_content => template('serverdensity_agent/plugin/disk.yaml.erb'),
+  }
+}

--- a/manifests/plugin/network.pp
+++ b/manifests/plugin/network.pp
@@ -1,0 +1,41 @@
+# == Class: serverdensity_agent::plugin::network
+#
+# Defines Network plugin configuration
+#
+# === Parameters
+#
+# [*excluded_interfaces*]
+#   Array. Define network interfaces to be excluded
+#   Default: ['lo','lo0']
+#
+# [*collect_connection_state*]
+#   Boolean. Enable collection of connection states
+#   Default: False
+#
+# [*excluded_interface_re*]
+#   Array, Define network interfaces to be excluded via regex
+#   Default: []
+#
+# [*combine_connection_states*]
+#   Boolean. Enable combineing of connection states
+#   Default: False
+#
+# === Examples
+#
+# class { 'serverdensity_agent::plugin::network':
+#   excluded_interfaces => ['lo','lo0'],
+#   collect_connection_state  => false,
+#   excluded_interface_re => [],
+#   combine_connection_states = false
+# }
+#
+class serverdensity_agent::plugin::network (
+    $excluded_interfaces = ['lo','lo0'],
+    $collect_connection_state  = false,
+    $excluded_interface_re = [],
+    $combine_connection_states = false
+  ) {
+  serverdensity_agent::plugin { 'network':
+    config_content => template('serverdensity_agent/plugin/network.yaml.erb'),
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",

--- a/templates/plugin/disk.yaml.erb
+++ b/templates/plugin/disk.yaml.erb
@@ -1,0 +1,28 @@
+init_config:
+
+instances:
+  - use_mount: <%= @use_mount %>
+<% if @excluded_filesystems -%>
+    excluded_filesystems:
+<% (Array(@excluded_filesystems)).each do |fs| -%>
+      - <%= fs %>
+<%- end -%>
+<% end -%>
+<% if @excluded_disks -%>
+    excluded_disks:
+<% (Array(@excluded_disks)).each do |disk| -%>
+      - <%= disk %>
+<% end -%>
+<% end -%>
+<% if @excluded_disk_re -%>
+    excluded_disk_re: <%= @excluded_disk_re %>
+<% end -%>
+<% if @excluded_mountpoint_re -%>
+    excluded_mountpoint_re: <%= @excluded_mountpoint_re %>
+<% end -%>
+<% if @all_partitions -%>
+    all_partitions: <%= @all_partitions %>
+<% end -%>
+<% if @tag_by_filesystem -%>
+    tag_by_filesystem: <%= @tag_by_filesystem %>
+<% end -%>

--- a/templates/plugin/network.yaml.erb
+++ b/templates/plugin/network.yaml.erb
@@ -1,0 +1,17 @@
+init_config:
+
+instances:
+  - collect_connection_state: <%= @collect_connection_state %>
+<% if !@excluded_interfaces.empty? -%>
+    excluded_interfaces:
+<%- (@excluded_interfaces.each do |i| -%>
+      - <%= i %>
+<% end ) -%>
+<% end -%>
+<% if !@excluded_interface_re.empty? -%>
+    excluded_interface_re:
+<%- (@excluded_interfaces_re.each do |i| -%>
+      - <%= i %>
+<% end ) -%>
+<% end -%>
+    combine_connection_states: <%= @combine_connection_states %>


### PR DESCRIPTION
The network and disk plugins ship by default with the packaged agent installs.

This PR adds the ability to configure the plugins via puppet. 

@pessoa can you review please? 

This might be helpful for testing:

```
class { 'serverdensity_agent':
    sd_account => 'example',
    agent_key  => '1234567890abcdef',
}

 class { 'serverdensity_agent::plugin::network':
   excluded_interfaces => ['lo','lo0'],
   collect_connection_state  => true,
   excluded_interface_re => [],
   combine_connection_states => true
 }

class { 'serverdensity_agent::plugin::disk':
    use_mount              => 'no',
    excluded_filesystems   => ['tmpfs', 'run'],
    excluded_disks         => ['/dev/sda', '/dev/sdb'],
    excluded_disk_re	   => '/dev/sda.*',
    excluded_mountpoint_re => '/mnt/no-monitor.*',
    all_partitions         => false,
    tag_by_filesystem	   => 'yes'
 }
```