### PR TITLE
Write agent key to local file

### DIFF
--- a/lib/facter/agent_key.rb
+++ b/lib/facter/agent_key.rb
@@ -12,6 +12,8 @@ Facter.add(:sd_agent_key, :timeout => 10) do
     # do this first as it's fast
     if File::exist?('/etc/sd-agent-key')
         result = Facter::Util::Resolution.exec("cat /etc/sd-agent-key")
+    elsif File::exist?('/var/run/sd-agent-key')
+        result = Facter::Util::Resolution.exec("cat /var/run/sd-agent-key")
     elsif Facter.value('ec2_instance_id')
         # use the amazon metadata api to
         # get user-data that we've set on
@@ -21,7 +23,7 @@ Facter.add(:sd_agent_key, :timeout => 10) do
         res = Net::HTTP.start(uri.host, uri.port) {|http|
                 http.request(req)
             }
-        
+
         result = res.body.split(':').last if res.code == 200
     end
 

--- a/lib/facter/agent_key.rb
+++ b/lib/facter/agent_key.rb
@@ -7,9 +7,9 @@ Facter.add(:sd_agent_key, :timeout => 10) do
     # just in case we don't get any of them
     result = nil
 
-    # We inject this file using the Rackspace api
-    # on instance creation
-    # do this first as it's fast
+    # We inject '/etc/sd-agent-key' using the Rackspace api when an
+    # instance is created via the Server Density Cloud integration.
+    # Do this first as it's fast
     if File::exist?('/etc/sd-agent-key')
         result = Facter::Util::Resolution.exec("cat /etc/sd-agent-key")
     elsif File::exist?('/var/run/sd-agent-key')

--- a/manifests/amazon.pp
+++ b/manifests/amazon.pp
@@ -12,7 +12,7 @@
 #
 
 class serverdensity_agent::amazon {
-  $repo_baseurl = "https://archive.serverdensity.com/el/6"
+  $repo_baseurl = 'https://archive.serverdensity.com/el/6'
   $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'
 
   yumrepo { 'serverdensity_agent':

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -60,4 +60,12 @@ class serverdensity_agent::config_file (
     mode   => '0755',
     notify => Class['serverdensity_agent::service'],
   }
+
+  # Write the agent key to a file so no api lookups are required
+  file { '/var/run/sd-agent-key':
+    ensure  => 'present',
+    replace => 'no',
+    content => $agent_key,
+    mode    => '0644',
+  }
 }

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -13,10 +13,10 @@
 
 class serverdensity_agent::config_file (
   $api_token,
-  $provided_agent_key = $::sd_agent_key,
   $sd_account,
   $server_group,
   $use_fqdn,
+  $provided_agent_key = $::sd_agent_key,
   $proxy_host = undef,
   $proxy_port = undef,
   $proxy_user = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,9 +143,9 @@ class serverdensity_agent(
   }
 
   # Include everything and let each module determine its own state
-  anchor { 'serverdensity_agent::begin': } ->
-  class { 'serverdensity_agent::service': } ->
-  anchor {'serverdensity_agent::end': }
+  anchor { 'serverdensity_agent::begin': }
+  -> class { 'serverdensity_agent::service': }
+  -> anchor {'serverdensity_agent::end': }
 
   class { 'serverdensity_agent::config_file':
     api_token          => $api_token,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,6 +38,5 @@ class serverdensity_agent::service {
   package {
     'sd-agent-sdstatsd':
       ensure  => $ensure_sdstatsd,
-      require => Apt::Source['serverdensity_agent'],
   }
 }


### PR DESCRIPTION
This PR writes the agent key to `/etc/sd-agent-key` so that an API request is not required. This should prevent devices being recreated in the rare event of an API lookup failure. 

Also cleaned up some puppet-lint errors too. 

@pessoa or @goll could you review? 