### PR TITLE
Use https everywhere

### DIFF
--- a/manifests/amazon.pp
+++ b/manifests/amazon.pp
@@ -12,7 +12,7 @@
 #
 
 class serverdensity_agent::amazon {
-  $repo_baseurl = "http://archive.serverdensity.com/el/6"
+  $repo_baseurl = "https://archive.serverdensity.com/el/6"
   $repo_keyurl = 'https://archive.serverdensity.com/sd-packaging-public.key'
 
   yumrepo { 'serverdensity_agent':

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -30,7 +30,7 @@ class serverdensity_agent::apt {
     'stretch' => 'stretch',
   }
 
-  $repo_baseurl = "http://archive.serverdensity.com/${downcase($::lsbdistid)}"
+  $repo_baseurl = "https://archive.serverdensity.com/${downcase($::lsbdistid)}"
   $repo_keyurl  = 'https://archive.serverdensity.com/sd-packaging-public.key'
 
   apt::source { 'serverdensity_agent':

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -12,7 +12,7 @@
 #
 
 class serverdensity_agent::yum {
-  $repo_baseurl = "http://archive.serverdensity.com/el/${::operatingsystemmajrelease}"
+  $repo_baseurl = "https://archive.serverdensity.com/el/${::operatingsystemmajrelease}"
 
   # March 31, 2017 can't arrive soon enough
   if $::operatingsystemmajrelease >= '5' and $::operatingsystemmajrelease < '6' {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",


### PR DESCRIPTION
This PR switches the repository URLs to https. 

Version bumped to 2.3.0 as this is potentially a breaking change for some users behind firewalls etc. 

@serverdensity/operations please can you review? 