### PR TITLE
Fix excluded interface re

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Check the class documentation for further details. Basic example:
 class { 'serverdensity_agent::plugin::network':
   excluded_interfaces => ['lo','lo0'],
   collect_connection_state  => true,
-  excluded_interface_re => [],
+  excluded_interface_re => 'eth*',
   combine_connection_states => true
 }
 ```

--- a/manifests/plugin/network.pp
+++ b/manifests/plugin/network.pp
@@ -13,8 +13,8 @@
 #   Default: False
 #
 # [*excluded_interface_re*]
-#   Array, Define network interfaces to be excluded via regex
-#   Default: []
+#   String, Define network interfaces to be excluded via regex
+#   Default: undef
 #
 # [*combine_connection_states*]
 #   Boolean. Enable combineing of connection states
@@ -25,14 +25,14 @@
 # class { 'serverdensity_agent::plugin::network':
 #   excluded_interfaces => ['lo','lo0'],
 #   collect_connection_state  => false,
-#   excluded_interface_re => [],
+#   excluded_interface_re => 'eth*',
 #   combine_connection_states = false
 # }
 #
 class serverdensity_agent::plugin::network (
     $excluded_interfaces = ['lo','lo0'],
     $collect_connection_state  = false,
-    $excluded_interface_re = [],
+    $excluded_interface_re = undef,
     $combine_connection_states = false
   ) {
   serverdensity_agent::plugin { 'network':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",

--- a/templates/plugin/network.yaml.erb
+++ b/templates/plugin/network.yaml.erb
@@ -8,10 +8,7 @@ instances:
       - <%= i %>
 <% end ) -%>
 <% end -%>
-<% if !@excluded_interface_re.empty? -%>
-    excluded_interface_re:
-<%- (@excluded_interfaces_re.each do |i| -%>
-      - <%= i %>
-<% end ) -%>
+<% if @excluded_interface_re -%>
+    excluded_interface_re: <%= @excluded_interface_re %>
 <% end -%>
     combine_connection_states: <%= @combine_connection_states %>


### PR DESCRIPTION
This PR fixes the `excluded_interface_re` option for the network plugin. A single string is now used instead of an array, as this is what the plugin requires: https://github.com/serverdensity/sd-agent-core-plugins/blob/master/network/check.py#L217

@pessoa @goll this is for you :)