### PR TITLE
Add Debian Buster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  - 1.9.3
 script: 'puppet parser validate `find . manifests -name "*.pp"`'
 script: 'puppet-lint --no-autoloader_layout-check --with-filename manifests'
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.4 (29-07-2019)
+* Added support for Debian Buster
+* Fix initial apt installation failure as the repo is added, but not refreshed.
+
 ## v2.3.3
 * Added basic support for SDStatsD plugin
 * Added Changelog

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ end
 gem 'rake'
 gem 'puppet-lint'
 gem 'rspec-puppet'
-gem 'json', '<= 1.8.3'
+gem 'json'

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -30,6 +30,7 @@ class serverdensity_agent::apt {
     'wheezy'  => 'wheezy',
     'jessie'  => 'jessie',
     'stretch' => 'stretch',
+    'buster'  => 'buster',
   }
 
   $repo_baseurl = "https://archive.serverdensity.com/${downcase($::lsbdistid)}"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "serverdensity-serverdensity_agent",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": "Server Density",
   "summary": "Puppet module to install the Server Density monitoring agent and register servers automatically.",
   "license": "Simplified BSD License",


### PR DESCRIPTION
* Adds support for Debian Buster
* Bumps version to 2.3.4. 
* Removed some version pins from Travis config to allow tests to run.

@goll can you review and merge if happy? 