### PR TITLE
Added Ubuntu Focal

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -16,6 +16,7 @@ class serverdensity_agent::apt {
     'artful'  => 'xenial',
     'bionic'  => 'bionic',
     'cosmic'  => 'bionic',
+    'focal' => 'focal',
     'precise' => 'all',
     'quantal' => 'all',
     'raring'  => 'all',


### PR DESCRIPTION
Since the [documentation](https://support.serverdensity.com/hc/en-us/articles/360001065583-Debian-Ubuntu-servers) tells us a Ubuntu Focal repository exists, this adds the change to allow it.